### PR TITLE
纠正目录中“用重载模拟函的数偏特化”

### DIFF
--- a/Professional-C++-6ed.tex
+++ b/Professional-C++-6ed.tex
@@ -585,7 +585,7 @@
 \mySection{第26章}{模板进阶}{content/part4/chapter26/0.tex}
 \mySubsection{26.1.}{模板参数}{content/part4/chapter26/1.tex}
 \mySubsection{26.2.}{类模板的偏特化}{content/part4/chapter26/2.tex}
-\mySubsection{26.3.}{用重载模拟函的数偏特化}{content/part4/chapter26/3.tex}
+\mySubsection{26.3.}{用重载模拟函数的偏特化}{content/part4/chapter26/3.tex}
 \mySubsection{26.4.}{模板递归}{content/part4/chapter26/4.tex}
 \mySubsection{26.5.}{变长模板}{content/part4/chapter26/5.tex}
 \mySubsection{26.6.}{元编程}{content/part4/chapter26/6.tex}


### PR DESCRIPTION
原来是错误的“用重载模拟函的数偏特化”，纠正为“用重载模拟函数的偏特化”. 